### PR TITLE
Lint guides

### DIFF
--- a/.mdlrc
+++ b/.mdlrc
@@ -1,0 +1,3 @@
+all
+
+exclude_rule "MD002", "MD013", "MD024", "MD026", "MD033", "MD034", "MD036"

--- a/guides/airflow-branch-operator.md
+++ b/guides/airflow-branch-operator.md
@@ -63,7 +63,7 @@ def get_recent_date():
     bing_date = PostgresHook('astro_redshift').get_pandas_df(
         """ SELECT max(gregorian_date) FROM dev.aa_bing_ads.conversion;""")['max'][0]
     google_date = PostgresHook('astro_redshift').get_pandas_df(
-        """ SELECT max(day) FROM dev.aa_google_adwords.cc_search_query_performance_report	; """)['max'][0]
+        """ SELECT max(day) FROM dev.aa_google_adwords.cc_search_query_performance_report   ; """)['max'][0]
     sf_date = PostgresHook('astro_redshift').get_pandas_df(
         """ SELECT max(created_date) FROM aa_salesforce.sf_lead; """)['max'][0].to_pydatetime().date()
     # Salesforce is never easy to work with.

--- a/guides/airflow-datastores.md
+++ b/guides/airflow-datastores.md
@@ -60,11 +60,13 @@ t2 = PythonOperator(
 ```
 
 ### Variables
+
 _Static Values_
 
 Similar to XComs, Variables are key-value stores in Airflow's metadata database. However, Variables are just key-value stores - they don't store the "conditions" (`execution_date`, `TaskInstance`, etc.) that led to a value being produced.
 
 Variables can be pushed and pulled in a similar fashion to `XComs`:
+
 ```python
 config = Variable.get("db_config")
 
@@ -107,6 +109,7 @@ XCom data can be deleted straight from the database.
 Variables can be used as static value stores to generate DAGs from config files.
 
 Define the variable:
+
 ```json
 [{
   "table": "users",
@@ -121,6 +124,7 @@ Define the variable:
  "s3_key":"app_two_users",
  "redshift_conn_id":"postgres_default"}]
  ```
+
 <br>
 Call the Variable in the dag file
 <br>
@@ -141,6 +145,7 @@ with dag:
         )
         start >> d1
 ```
+
 ![variable_dag](img/variable_dag.png)
 
 This can be an especially powerful method of defining any database sync workflows - the first step in the DAG can generate a list of tables and schemas with their corresponding transformation, and downstream tasks can perform the necessary queries.

--- a/guides/airflow-ui.md
+++ b/guides/airflow-ui.md
@@ -34,6 +34,7 @@ Paused DAGs can be toggled to be hidden from the UI - but we would advise agains
 ![paused_dags](https://cdn.astronomer.io/website/img/guides/paused_dags.png)
 
 ## Admin Panel
+
 The Admin panel will have information regarding things that are ancillary to DAGs. Note that for now, Astronomer handles the _Pools_ and _Configuration_ views as environment variables, so they cannot be changed from the UI.
 
 ![admin](https://cdn.astronomer.io/website/img/guides/admin_views.png)
@@ -51,6 +52,7 @@ This view won't be helpful for much at the moment, but it will be roped into the
 Airflow needs to know how to connect to your environment. Connections is where you can store that information - anything from hostname, to port, to logins to other systems. The pipeline code you will author will reference the ‘conn_id’ of the Connection objects.
 
 The Airflow Variables section can also hold such information, but storing them as Connections allows:
+
 - Encryption on passwords and extras.
 - Common JSON structure for connections:
 
@@ -65,6 +67,7 @@ However, a Docker Registry will look like this:
 ![docker](https://cdn.astronomer.io/website/img/guides/docker_registry.png)
 
 However, they can both be called as such:
+
 ```python
 from airflow.hooks.base_hook import BaseHook
 ...
@@ -117,12 +120,12 @@ Double-clicking on an individual task offers a few options:
 
 ![task_options](https://cdn.astronomer.io/website/img/guides/task_options.png)
 
-- ** Task Instance Details:**  Shows the fully rendered task - an exact summary of what the task does (attributes, values, templates, etc.)
-- ** Rendered: ** Shows the task's metadata after it's been templated
-- ** Task Instances** A historical view of that particular task - times it ran successfully, failed, was skipped, etc.
-- ** View Log:** Brings you to Logs of that particular taskinstance.
-- ** Clear: ** Removes that task runs existence from Airflow's metadata. This clears all downstream tasks and runs that task and all downstream tasks again. (**This is the recommended way to re-run a task **).
-- ** Mark Success:** Sets a task to success. This will update the task's status in the metadata and allow downstream tasks to run.
+- **Task Instance Details:**  Shows the fully rendered task - an exact summary of what the task does (attributes, values, templates, etc.)
+- **Rendered:** Shows the task's metadata after it's been templated
+- **Task Instances** A historical view of that particular task - times it ran successfully, failed, was skipped, etc.
+- **View Log:** Brings you to Logs of that particular taskinstance.
+- **Clear: ** Removes that task runs existence from Airflow's metadata. This clears all downstream tasks and runs that task and all downstream tasks again. (**This is the recommended way to re-run a task **).
+- **Mark Success:** Sets a task to success. This will update the task's status in the metadata and allow downstream tasks to run.
 
 ### Code View
 
@@ -140,7 +143,7 @@ This shows a summary for the past run of the DAG. There's no information that is
 
 ## Data Profiling
 
-###  Visualizing Metadata
+### Visualizing Metadata
 
 Airflow offers a slew of metadata on individual DAG runs along with a few visualizations.
 
@@ -166,7 +169,7 @@ Tasks will NOT automatically re-run if the DAG has failed (which you'll notice b
 
 1. Browse > Task Instances, filter for and select the failed task(s), and Delete (this is essentially the same as clearing individual tasks in the DAG graph or tree view).
 
-2. Browse > DAG Runs, filter for and select the failed DAG(s), and set state to 'running.'
+1. Browse > DAG Runs, filter for and select the failed DAG(s), and set state to 'running.'
 
 This will automatically trigger a DAG re-run start|ing with the first unsuccessful task(s).
 
@@ -179,6 +182,7 @@ _Note_: The task and DAG status field on your main dashboard may take a bit to r
 ![delete_task_instances](https://cdn.astronomer.io/website/img/guides/delete_task_instances.png)
 
 ### DAGs
+
 The same can be done for DAGs from **Browse-> DAG Runs**. This can be particularly helpful when migrating databases or re-running all history for a job with just a small change.
 
 ![browse_dag_runs](https://cdn.astronomer.io/website/img/guides/browse_dag_runs.png)

--- a/guides/airflow-vs-aws-glue.md
+++ b/guides/airflow-vs-aws-glue.md
@@ -12,17 +12,21 @@ You may have come across AWS Glue mentioned as a code-based, server-less ETL alt
 ## Platform
 
 ### Airflow
+
 Airflow is an open-sourced project that (with a few executor options) can be run anywhere in the cloud (e.g. AWS, GCP, Azure, etc). With [Astronomer Enterprise](http://enterprise.astronomer.io/), you can run Airflow on Kubernetes either on-premise or in any cloud.
 
 ### AWS Glue
+
 Glue is an AWS product and cannot be implemented on-premise or in any other cloud environment.
 
 ## Purpose
 
 ### Airflow
+
 Airflow is designed to be an incredibly flexible task scheduler; there really are no limits of how it can be used. Often, it is used to perform ETL jobs (see the ETL section of [Example Airflow Dags](https://github.com/airflow-plugins/Example-Airflow-DAGs), but it can easily be used to [train ML models](https://wecode.wepay.com/posts/training-machine-learning-models-with-airflow-and-bigquery), [check the state of different systems and send notifications via email/slack](https://www.astronomer.io/blog/automating-salesforce-reports-in-slack-with-airflow-3/), and [power features within an app using various APIs](https://robinhood.engineering/why-robinhood-uses-airflow-aed13a9a90c8?gi=e3d130abaf1a).
 
 ### Glue
+
 Glue is designed to make the processing of your data as easy as possible ONCE it is the AWS ecosystem. According to AWS Glue documentation:
 
 "AWS Glue natively supports data stored in Amazon Aurora, Amazon RDS for MySQL, Amazon RDS for Oracle, Amazon RDS for PostgreSQL, Amazon RDS for SQL Server, Amazon Redshift, and Amazon S3, as well as MySQL, Oracle, Microsoft SQL Server, and PostgreSQL databases in your Virtual Private Cloud (Amazon VPC) running on Amazon EC2.
@@ -34,26 +38,31 @@ Because of this, it can be advantageous to still use Airflow handle the data pip
 ## Underlying Framework
 
 ### Airflow
+
 Airflow is an independent framework that executes native Python code without any other dependencies. This can then be extended to use other services, such as [Apache Spark](https://github.com/apache/incubator-airflow/blob/master/airflow/contrib/operators/spark_submit_operator.py), using the library of officially supported and community contributed operators.
 
 ### Glue
+
 Glue uses Apache Spark as the foundation for it's ETL logic. There are some notable differences, however, that differentiate it from traditional Spark. The biggest of these differences include the use of a "dynamic frame" vs. the "data frame" (in Spark) that adds a number of additional Glue methods including [ResolveChoice()](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-crawler-pyspark-transforms-ResolveChoice.html), [ApplyMapping()](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-crawler-pyspark-transforms-ApplyMapping.html), and [Relationalize()](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-crawler-pyspark-transforms-Relationalize.html).
 
 ## Execution
 
 ### Airflow
+
 Airflow can be executed in a number of fashions; the most common of which is the [CeleryExecutor](https://github.com/apache/incubator-airflow/blob/master/airflow/executors/celery_executor.py). Other [executors](https://github.com/apache/incubator-airflow/tree/master/airflow/executors) are currently available and compatibility with other platforms can be written to extend the framework (such as the [Mesos](https://github.com/apache/incubator-airflow/blob/master/airflow/contrib/executors/mesos_executor.py) or [Kubernetes](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=71013666) Executors).
 
 Airflow on Astronomer (Enterprise) runs on a private Kubernetes cluster and includes resource management tooling and analytics including Prometheus, [Grafana](https://grafana.com/), and [StatsD](https://github.com/etsy/statsd).
 
 ### Glue
+
 AWS Glue is notably "server-less", meaning that it requires no specific resources to manage.
 
 ## Pricing
 
 ### Airflow
+
 While it can be pretty difficult to get up and running alone, Airflow is an open-source project that's completely free to use. If you think you could use some help managing infrastructure or getting Airflow training, check out our [products](https://astronomer.io) and shoot us an email at humans@astronomer.io if you'd like to chat.
 
-
 ### Glue
+
 Pricing on Glue is determined using the derived measure of "Data Processing Units." More information can be found on their [Pricing Page](https://aws.amazon.com/glue/pricing/).

--- a/guides/airflow-vs-oozie.md
+++ b/guides/airflow-vs-oozie.md
@@ -25,8 +25,7 @@ Oozie is an open-source workflow scheduling system written in Java for Hadoop sy
 
 While it has been used successfully by a few teams, [it has been reported](https://stackoverflow.com/questions/47928995/which-one-to-choose-apache-oozie-or-apache-airflow-need-a-comparison) that Oozie has difficulty handling complex pipelines and has an underdeveloped GUI that is challenging to navigate.
 
-
-# Key Differences 
+# Key Differences
 
 ## Python vs. Java
 
@@ -40,11 +39,9 @@ Airflow is the most active workflow management tool on the market and has 8,636 
 
 ![airflow](https://s3.amazonaws.com/astronomer-cdn/website/img/guides/Screen+Shot+2018-07-10+at+4.26.28+PM.png)
 
-
 Oozie has 386 stars and 16 active contributors on Github. See below for an image documenting code changes caused by recent commits to the project.
 
 ![oozie](https://s3.amazonaws.com/astronomer-cdn/website/img/guides/Screen+Shot+2018-07-10+at+4.26.17+PM.png)
-
 
 Note that, with open source projects, community contributions are significant in that they're reflective of the community's faith in the future of the project and indicate that features are actively being developed.
 
@@ -52,19 +49,18 @@ Note that, with open source projects, community contributions are significant in
 
 As pointed out by [Stack Overflow user Michele De Simoni](https://stackoverflow.com/users/8050556/michele-ubik-de-simoni), there are a few reasons why Airflow is preferred over Oozie by the community for workflow management.
 
-
 ### Airflow
 
-+ Python Code for DAGs (+)
-+ Has connectors for every major service/cloud provider (+)
-+ More versatile (+)
-+ Advanced metrics (+)
-+ Better UI and API (+)
-+ Capable of creating extremely complex workflows (+)
-+ Jinja Templating (+)
-+  Can be parallelized (=)
-+ Native Connections to HDFS, HIVE, PIG etc.. (=)
-+  Graph as DAG (=)
+- Python Code for DAGs (+)
+- Has connectors for every major service/cloud provider (+)
+- More versatile (+)
+- Advanced metrics (+)
+- Better UI and API (+)
+- Capable of creating extremely complex workflows (+)
+- Jinja Templating (+)
+- Can be parallelized (=)
+- Native Connections to HDFS, HIVE, PIG etc.. (=)
+- Graph as DAG (=)
 
 ### Oozie
 

--- a/guides/cli.md
+++ b/guides/cli.md
@@ -7,7 +7,6 @@ heroImagePath: "https://cdn.astronomer.io/website/img/guides/markus-spiske-20794
 tags: ["Airflow", "CLI", "Product Documentation"]
 ---
 
-
 The Astro CLI helps users create and test activities and deploy those activities and Astronomer/community pre-built activities in actual DAGs. Once DAGs have been tested locally, users can deploy them to our public cloud or their private installation.
 
 ## Prerequisites
@@ -21,6 +20,7 @@ You should also make sure you Go installed (pip and Python too, but they're pack
 ```
 brew install go
 ```
+
 More info: https://golang.org/doc/install
 
 ## Setup
@@ -40,7 +40,6 @@ mkdir /path/to/project
 cd /path/to/project
 ~~~
 
-
 ## Local Airflow
 
 Run `astro airflow up` to start the local airflow cluster.
@@ -49,7 +48,6 @@ Once started, it can be accessed at `http://localhost:8080`.
 
 This will start a local version of Astronomer Airflow on your machine along with a local Postgres database.
 (Run `docker ps` to see the images)
-
 
 Once finished you can run `astro airflow down` to stop the cluster.
 
@@ -98,9 +96,7 @@ dummy_operator >> hello_operator
 Login:
 `astro login`
 
-
 And now we're ready to deploy (make sure your user belongs to an organization):
-
 
 ~~~
 astro deploy
@@ -110,7 +106,6 @@ This will prompt you to select the organization, and confirms you are sure you w
 Once you do that, it will bundle all but a few blacklisted files and push to the API, and then to S3.
 
 **Note**: Information in the `Connections` panel and metadata on local DAG runs will not get pushed up.
-
 
 If you want to log out of your account:
 
@@ -157,28 +152,29 @@ How to get started as a developer.
 
 1. Build:
 
-    ```
-    $ git clone git@github.com:astronomerio/astro-cli.git
-    $ cd astro-cli
-    $ make build
-    ```
+  ```
+  $ git clone git@github.com:astronomerio/astro-cli.git
+  $ cd astro-cli
+  $ make build
+  ```
 
 1. (Optional) Install to `$GOBIN`:
 
-    ```
-    $ make install
-    ```
+  ```
+  $ make install
+  ```
 
 1. Run:
 
-    ```
-    $ astro
-    ```
-    
+  ```
+  $ astro
+  ```
+
 ### Old Deploys
 
 In your project directory there will be a hidden `.astro` folder that contains past deploys (made from that machine).
 
 ### Metadata
+
 When running/building locally you will need to generate the metadata file.  Running `make build-meta` or a `make build`
 will build the meta data file. Once generated, you should be able to build/run without problem.

--- a/guides/connections.md
+++ b/guides/connections.md
@@ -13,7 +13,8 @@ Connections can be maintained in the Airflow Interface (Menu --> Admin --> Conne
 
 ### Example Connection Configurations
 
-##### Microsoft SQL Server
+#### Microsoft SQL Server
+
 * `Host`: localhost
 * `Schema`: n/a
 * `Login`: _your username_
@@ -21,7 +22,8 @@ Connections can be maintained in the Airflow Interface (Menu --> Admin --> Conne
 * `Port`: 1433
 * `Extras`: n/a
 
-##### MongoDb
+#### MongoDb
+
 * `Host`:
 * `Schema`: Authentication Database
 * `Login`:
@@ -29,7 +31,8 @@ Connections can be maintained in the Airflow Interface (Menu --> Admin --> Conne
 * `Port`: 27017
 * `Extras`: JSON Object of [connection options](https://docs.mongodb.com/manual/reference/connection-string/#connection-string-options)
 
-##### MySQL
+#### MySQL
+
 * `Host`: localhost
 * `Schema`: _your database name_
 * `Login`: _your username_
@@ -37,7 +40,8 @@ Connections can be maintained in the Airflow Interface (Menu --> Admin --> Conne
 * `Port`: 3306
 * `Extras`: n/a
 
-##### S3
+#### S3
+
 * `Host`: n/a
 * `Schema`: n/a
 * `Login`: n/a
@@ -45,7 +49,8 @@ Connections can be maintained in the Airflow Interface (Menu --> Admin --> Conne
 * `Port`: n/a
 * `Extras`: {"aws_access_key_id":" ","aws_secret_access_key":" "}
 
-##### Postgres
+#### Postgres
+
 * `Host`: localhost
 * `Schema`: _your database name_
 * `Login`: _your username_
@@ -54,4 +59,5 @@ Connections can be maintained in the Airflow Interface (Menu --> Admin --> Conne
 * `Extras`: n/a
 
 ### A note about the Schema field
+
 The `Schema` field in Airflow can potentially be a source of confusion as many databases have different meanings for the term.  In Airflow a schema refers to the database name to which a connection is being made.  For example, for a Postgres connection the name of the database should be entered into the `Schema` field and the Postgres idea of schemas should be ignored (or put into the `Extras` field) when defining a connection.

--- a/guides/dag-best-practices.md
+++ b/guides/dag-best-practices.md
@@ -8,6 +8,7 @@ tags: ["DAGs", "Data Pipelines", "Airflow"]
 ---
 
 ### Idempotency
+
 Data pipelines are a messy business with a lot of various components that can fail. [Idempotent](https://en.wikipedia.org/wiki/Idempotence) DAGs allow you to deliver results faster when something breaks and can save you from losing data down the road.
 
 ### Use Retries
@@ -19,25 +20,30 @@ A [zombie process](https://en.wikipedia.org/wiki/Zombie_process) occurs when Air
 This can often be resolved by bumping up retries on the task. A good range to try is ~2–4 retries.
 
 ### Incremental Record Filtering
+
 When possible, seek to break out your pipelines into incremental extracts and loads. This results in each DagRun representing only a small subset of your total dataset. This means that a failure in one subset of the data won't affect the rest of your DagRuns from completing successfully.
 
 There are three ways you can achieve incremental pipelines.
 
 #### Last Modified Date
+
 This is the gold standard for incremental loads. Ideally each record in your source system contains a column containing the last time the record was modified. Every DAG run then looks for records that were updated within it's specified date parameters.
 
 For example, a DAG that runs hourly will have 24 runs times a day. Each DAG run will be responsible for loading any records that fall between the start and end of it's hour. When any of those runs fail it will not stop the others from continuing to run.
 
 #### Sequence IDs
+
 When a last modified date is not available, a sequence or incrementing ID, can be used for incremental loads. This logic works best when the source records are only being appended to and never updated. If the source records are updated you should seek to implement a Last Modified Date in that source system and key your logic off of that. In the case of the source system not being updated, basing your incremental logic off of a sequence ID can be a sound way to filter pipeline records without a last modified date.
 
 ### Limit how much data gets pulled into a task.
+
 Every task gets run in its own container with limited memory (based on the selected plan) in Astronomer Cloud. If the task container doesn't have enough memory for a task, it will fail with:
 `{jobs.py:2127} INFO - Task exited with return code -9`.
 
 Try to limit in memory manipulations (some packages like pandas are very memory intensive) and use intermediary data storage whenever possible.
 
 ### Intermediary Data Storage
+
 It can be tempting to write your DAGs so that they move data directly from your source to destination. It usually makes for less code and involves less pieces, but doing so removes your ability to re-run just the extract or load portion of the pipeline individually. By putting an intermediary storage layer such as S3 or SQL Staging tables in between your source and destination, you can separate the testing and re-running of the extract and load.
 
 If you are using s3 as your intermediary, it is best to set a policy restricted to a dedicated s3 bucket to use in your Airflow s3 connection object. This policy will need to read, write, and delete objects.
@@ -65,6 +71,7 @@ An example policy allowing this is below:
     ]
 }
 ```
+
 For more details, please visit: https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources
 
 Depending on your data retention policy you could modify the load logic and re-run the entire historical pipeline without having to re-run the extracts. This is also useful in situations where you no longer have access to the source system (i.e. hit an API limit).
@@ -78,27 +85,32 @@ For example, the `s3_key` and `since` and `until` fields are set as `template_fi
 
  This allows for these values to be dynamically set by the `schedule_interval`.
 
-
 ### depends_on_past and wait_for_downstream can be used for added safety
+
 `depends_on_past` and `wait_for_downstream` are set at the DAG level, but filters down to tasks. If `depends_on_past` is set to `true`, the previously scheduled task instance needs to have succeeded before the next task instance will be scheduled (assuming all dependencies are met). Additionally, if `wait_for_downstream` is set to `true`, a task will wait for all tasks downstream of the previously scheduled task to finish before being scheduled.
 
 Using these effectively can help ensure data integrity when scheduling a backfill where data is aggregated by some time interval.
 
 ### Static start_date
+
 A dynamic start_date is misleading. It can cause failures when clearing out failed task instances and missing DAG runs.
 
 ## Transformations
+
 Look to implement an ELT (extract, load, transform) data pipeline pattern with your DAG definition file. This means that you should look to offload as much of the transformation logic to the source systems or the destinations systems as possible. With python at your fingertips it can be tempting to attempt the transformations in the DAG but offloading those transformations to the source or destination systems will lead to better overall performance and keeps your DAG lean and readable.
 
 ### Use Staging Tables
+
 Try to use staging tables before pushing to a final destination. This makes debugging errors easier as you'll have the exact data that caused an error and adds a layer of safety.
 
 **Note** By default, each task counts as its own database session, so avoid temporary tables that only last a session. Instead, have the last task in your DAG clear out intermediary tables if everything runs successfully.
 
 ### Mongo Source
+
 Use [aggregation pipelines](https://docs.mongodb.com/manual/core/aggregation-pipeline/) to perform your transformations on extract from a Mongo source.
 
 ### SQL Source
+
 Try to do basic transformations and aggregations in SQL queries - this offloads transformation logic onto the source system and keeps your DAG readable.
 
 ## Readability
@@ -122,14 +134,17 @@ plugin_name/
 See [here](https://github.com/airflow-plugins/) for examples!
 
 ### Change the name of your DAG when you change the start date.
+
 Changing the `start_date` of a DAG creates a new entry in Airflow's database, which could confuse the scheduler because there will be two DAGs with the same name but different schedules.
 
 Changing the name of a DAG also creates a new entry in the database, which powers the dashboard, so follow a consistent naming convention since changing a DAG's name doesn't delete the entry in the database for the old name.
 
 ### Avoid top level code in your DAG file.
+
 The Airflow executor executes top level code on every heartbeat, so a small amount of top level code can cause performance issues. Try to treat the DAG file like a config file and leave all the heavy lifting for the hook and operator.
 
 ### Task Dependencies
+
 Task dependencies are set using `set_upstream()` and `set_upstream()`. Using either will depend on your preferences, but it is best to stay consistent with which one you use.
 
 #### Example

--- a/guides/dags.md
+++ b/guides/dags.md
@@ -32,13 +32,13 @@ Directed Acyclic Graph: Finally, a directed acyclic graph is a directed graph wi
 In Airflow, each node in a DAG (soon to be known as a task) represents some form of data processing:
 
 > Node A could be the code for pulling data out of an API.
-
+>
 > Node B could be the code for anonymizing the data and dropping any IP address.
-
+>
 > Node D could be the code for checking that no duplicate record ids exist.
-
+>
 > Node E could be putting that data into a database.
-
+>
 > Node F could be running a SQL query on the new tables to update a dashboard.
 
 ## Dependencies
@@ -63,7 +63,7 @@ DAGs are a natural fit for batch architecture - they allow you to model natural 
 
 **Graph** - All tasks are laid out in a clear structure with discrete processes occurring at set points and clear relationships made to other tasks.
 
-##  DAGs as Functional Programming
+## DAGs as Functional Programming
 
 https://medium.com/@maximebeauchemin/functional-data-engineering-a-modern-paradigm-for-batch-data-processing-2327ec32c42a
 

--- a/guides/dynamically-generating-dags.md
+++ b/guides/dynamically-generating-dags.md
@@ -8,7 +8,6 @@ tags: ["Airflow", "DAGS"]
 ---
 The simplest way of creating a DAG in Airflow is to define it in the DAGs folder. Anything with a .py suffix will be scanned to see if it contains the definition of a new DAG.
 
-
 ```python
 from datetime import datetime
 
@@ -48,7 +47,6 @@ A common use case for this is when pulling data from multiple APIs or database t
 
 To create new dags, we're going to create a dag template within the `create_dag` function. The code here is almost identical to the previous code above when only one dag was being created but now it is wrapped in a method that allows for custom parameters to be passed in.
 
-
 ```python
 from datetime import datetime
 
@@ -80,7 +78,6 @@ def create_dag(dag_id,
 ```
 
 We can then set a simple loop (`range(1, 10)`) to generate these unique parameters and pass them to the global scope, thereby registering them as valid DAGs to the Airflow scheduler.
-
 
 ```python
 from datetime import datetime
@@ -139,7 +136,6 @@ Taking this a step further, the input parameters don't have to exist in the dag 
 ![title](https://cdn.astronomer.io/website/img/guides/dag_number_var.png)
 
 We can retrieve this value by importing the Variable class and passing it into our `range`. Because we want the interpreter to register this file as valid regardless of whether the variable exists, the `default_var` is set to 10.
-
 
 ```python
 from datetime import datetime
@@ -204,12 +200,11 @@ Then we can go to the main UI and see all of the new DAGs that have been created
 
 ## Adding DAGs based on Connections
 
-Creating DAGs based on a varible or set of variables is a very powerful feature of Airflow. But what if we want our number of DAGs to correspond to the number of connections (to an API, database, etc.) that are created in the "Connections" tab? In that case, we wouldn't want to have to create an additional variable uncessarily every time we made a new connection -- that would be redundant. 
+Creating DAGs based on a varible or set of variables is a very powerful feature of Airflow. But what if we want our number of DAGs to correspond to the number of connections (to an API, database, etc.) that are created in the "Connections" tab? In that case, we wouldn't want to have to create an additional variable uncessarily every time we made a new connection -- that would be redundant.
 
 Instead, we can pull the connections we have in our database by instantiating the "Session" and querying the "Connection" table. We can even filter our query so that this only pulls connections that match a certain criteria.
 
 ![title](https://cdn.astronomer.io/website/img/guides/connections.png)
-
 
 ```python
 from datetime import datetime
@@ -270,4 +265,4 @@ Notice that like before we are accessing the Models library to bring in the `Con
 
 ![title](https://cdn.astronomer.io/website/img/guides/connection_dags.png)
 
-We can see that all of the connections that match our filter have now been created as a unique DAG. The one connection we had which did not match (`SOME_OTHER_DATABASE`) has been ignored. 
+We can see that all of the connections that match our filter have now been created as a unique DAG. The one connection we had which did not match (`SOME_OTHER_DATABASE`) has been ignored.

--- a/guides/external-airflow-resources.md
+++ b/guides/external-airflow-resources.md
@@ -11,9 +11,10 @@ Below, you'll find a categorized selection of blog posts, decks, guides and use 
 
 If you've read or written something that you think should be on here,
 tweet us at [@astronomerio](https://twitter.com/astronomerio/)
-or shoot over an email to [humans@astronomer.io](mailto:humans@astronomer.io) 
+or shoot over an email to [humans@astronomer.io](mailto:humans@astronomer.io)
 
 ## Airflow 101
+
 * [“Apache Airflow for the confused explained using airplanes ✈️”][13] - Jonathan Pichot, NYC City Planning
 * [“Apache Airflow and the Future of Data Engineering: A Q&A”][20] - Maxime Beauchemin, Lyft
 * [“Modern Data Pipelines with Apache Airflow (Momentum 2018 talk)”][5] - Taylor Edmiston & Andy Cooper, Astronomer
@@ -24,15 +25,15 @@ or shoot over an email to [humans@astronomer.io](mailto:humans@astronomer.io)
 * [“Installing and Configuring Apache Airflow”][22] - Robert Sanders, Clairvoyant
 * [“Airflow: A Beautiful Cron Alternative (or replacement) for Data Pipelines and Workflows”][23] - rbahaguejr, cp-union.com
 
-
 ## Airflow Learnings
+
 * [“Improving Airflow UI Security”][1] - Joy Gao, WePay
 * [“Airflow Part 2: Lessons learned”][2]  - Nehil Jain, SnapTravel
 * [“What we learned migrating off Cron to Airflow”][6] - Katie Macias, VideoAmp
 * [“Airflow: Why is nothing working?”][8] - Jessica Laughlin, Bluecore
 
-
 ## Airflow Use Cases
+
 * [“How Sift Trains Thousands of Models using Apache Airflow”][7] - Duy Tran, Sift
 * [“How to create a workflow in Apache Airflow to track disease outbreaks in India”][0] - Vinayak Mehta, Social Cops
 * [“Airflow at Zillow: Easily Authoring and Managing ETL Pipelines”][15] - Tianlong Song, Zillow
@@ -51,6 +52,7 @@ or shoot over an email to [humans@astronomer.io](mailto:humans@astronomer.io)
 * ["Productionizing ML Workflows at Twitter"][33] - Samuel Ngahane and Devin Goodsell
 
 ## Data Engineering
+
 * [“A Beginner’s Guide to Data Engineering — Part I”][10] - Robert Chang, Airbnb
 * [“A Beginner’s Guide to Data Engineering — Part II”][9] - Robert Chang, Airbnb
 * [A Beginner's Guide to Data Engineering - The Series Finale][29] - Robert Chang, Airbnb
@@ -58,9 +60,8 @@ or shoot over an email to [humans@astronomer.io](mailto:humans@astronomer.io)
 * [“Why data automation matters for open data portals”][18] - Maksim Pecherskiy, City of San Diego
 
 ## Other
+
 * [Awesome Airflow Resources](https://github.com/jghoman/awesome-apache-airflow)  - A great collection of Airflow Resources in a dedicated GitHub repo, curated by [Jakob Homan](https://twitter.com/BlueBoxTraveler)
-
-
 
 [0]: https://blog.socialcops.com/engineering/apache-airflow-disease-outbreaks-india/ "How to create a workflow in Apache Airflow to track disease outbreaks in India"
 [1]: https://wecode.wepay.com/posts/improving-airflow-ui-security "Improving Airflow UI Security"

--- a/guides/facebook-ads-to-redshift.md
+++ b/guides/facebook-ads-to-redshift.md
@@ -10,40 +10,44 @@ tags: ["Building DAGs", "Redshift", "Facebook Ads"]
 In this guide, we’ll explore how you can use [Apache Airflow](https://airflow.apache.org/) to move your ad data from Facebook Ads to Redshift. Note that this is an effective and flexible alternative to point-and-click ETL tools like [Segment](https://segment.com), [Alooma](https://alooma.com), [Xplenty](https://xplenty.com), [Stitch](https://stitchdata.com), and [ETLeap](https://etleap.com/).
 
 Before we get started, be sure you have the following on hand:
-* A Facebook Ads
-* An S3 bucket with a valid `aws_access_key_id` and `aws_secret_access_key`
-* A Redshift instance with a valid host IP and login information
-* An instance of Apache Airflow. You can either set this up yourself if you have devops resources or sign up and get going immediately with Astronomer’s managed Airflow service. Note that this guide will use commands using the Astronomer CLI to push dags into production and will assume you’ve spun up an Airflow instance via Astronomer, but the core code should work the same regardless of how you’re hosting Airflow
-* Docker running on your machine
+
+- A Facebook Ads
+- An S3 bucket with a valid `aws_access_key_id` and `aws_secret_access_key`
+- A Redshift instance with a valid host IP and login information
+- An instance of Apache Airflow. You can either set this up yourself if you have devops resources or sign up and get going immediately with Astronomer’s managed Airflow service. Note that this guide will use commands using the Astronomer CLI to push dags into production and will assume you’ve spun up an Airflow instance via Astronomer, but the core code should work the same regardless of how you’re hosting Airflow
+- Docker running on your machine
 
 ### This DAG will create four breakdown reports:
-    - age_gender
-    - device_platform
-    - region_country
-    - no_breakdown
+
+- age_gender
+- device_platform
+- region_country
+- no_breakdown
+
 ### The standard fields included in each report are as follows:
-    - account_id
-    - ad_id
-    - adset_id
-    - ad_name
-    - adset_name
-    - campaign_id
-    - date_start
-    - date_stop
-    - campaign_name
-    - clicks
-    - cpc
-    - cpm
-    - cpp
-    - ctr
-    - impressions
-    - objective
-    - reach
-    - social_clicks
-    - social_impressions
-    - social_spend
-    - spend
-    - total_unique_actions
+
+- account_id
+- ad_id
+- adset_id
+- ad_name
+- adset_name
+- campaign_id
+- date_start
+- date_stop
+- campaign_name
+- clicks
+- cpc
+- cpm
+- cpp
+- ctr
+- impressions
+- objective
+- reach
+- social_clicks
+- social_impressions
+- social_spend
+- spend
+- total_unique_actions
 
 ### 1. Add Connections in Airflow UI
 
@@ -64,6 +68,7 @@ Navigate back into your project directory and create a `dags` folder by running 
 ### 4. Customize
 
 Open up the [facebook_ads_to_redshift.py file](https://github.com/airflow-plugins/Example-Airflow-DAGs/blob/master/etl/facebook_ads_to_redshift.py#L51) from the repo you just cloned in a text editor of your choice and fill out the following fields fin lines 51-56:
+
 ```py
 FACEBOOK_CONN_ID = ''
 ACCOUNT_ID = ''
@@ -76,7 +81,5 @@ REDSHIFT_SCHEMA = ''
 ### 5. Test + Deploy
 
 Once you have those credentials plugged into your DAG, test and deploy it!
-
-
 
 If you don't have Airflow already set up in your production environment, head over to [our app](https://app.astronomer.io/signup) to get spun up with your own managed instance!

--- a/guides/github-to-redshift.md
+++ b/guides/github-to-redshift.md
@@ -48,6 +48,7 @@ Navigate back into your project directory and create a `dags` folder by running 
 ### 4. Customize
 
 Open up the [github_to_redshift.py file](https://github.com/airflow-plugins/Example-Airflow-DAGs/blob/master/etl/github_to_redshift.py#L29) that you just copied in a text editor of your choice and input the following credentials into lines 29-35:
+
 ```
 S3_CONN_ID = ''
 S3_BUCKET = ''
@@ -61,7 +62,5 @@ LOAD_TYPE = ''
 ### 5. Test + Deploy
 
 Once you have those credentials plugged into your DAG, test and deploy it!
-
-
 
 If you don't have Airflow already set up in your production environment, head over to [our app](https://app.astronomer.io/signup) to get spun up with your own managed instance!

--- a/guides/google-analytics-to-redshift.md
+++ b/guides/google-analytics-to-redshift.md
@@ -23,19 +23,21 @@ Before we get started, be sure you have the following on hand:
 This DAG generates a report using v4 of the Google Analytics Core Reporting API. The dimensions and metrics are as follows. Note that while these can be modified, a maximum of 10 metrics and 7 dimensions can be requested at once.
 
 METRICS
- * pageView
- * bounces
- * users
- * newUsers
- * goal1starts
- * goal1completions
+
+* pageView
+* bounces
+* users
+* newUsers
+* goal1starts
+* goal1completions
 
 DIMENSIONS
- * dateHourMinute
- * keyword
- * referralPath
- * campaign
- * sourceMedium
+
+* dateHourMinute
+* keyword
+* referralPath
+* campaign
+* sourceMedium
 
 Not all metrics and dimensions are compatible with each other. When forming the request, please refer to the official [Google Analytics API Reference docs](https://developers.google.com/analytics/devguides/reporting/core/dimsmets)
 
@@ -58,6 +60,7 @@ Navigate back into your project directory and create a `dags` folder by running 
 ### 4. Customize
 
 Open up the [google_analytics_to_redshift.py file](https://github.com/airflow-plugins/Example-Airflow-DAGs/blob/master/etl/google_analytics_to_redshift.py#L46) that you just copied in a text editor of your choice and input the following credentials into lines 46-50:
+
 ```py
 S3_CONN_ID = ''
 S3_BUCKET = ''
@@ -69,7 +72,5 @@ REDSHIFT_SCHEMA = ''
 ### 5. Test + Deploy
 
 Once you have those credentials plugged into your DAG, test and deploy it!
-
-
 
 If you don't have Airflow already set up in your production environment, head over to [our app](https://app.astronomer.io/signup) to get spun up with your own managed instance!

--- a/guides/hubspot-to-redshift.md
+++ b/guides/hubspot-to-redshift.md
@@ -28,35 +28,35 @@ The associated scope to the varius endpoints can be found in the "scope" field w
 
 *NOTE:* The contacts table and associated subtables are built based on an incrementing contact id that is stored as an Airflow Variable with the
 naming convention "INCREMENTAL_KEY__{DAG_ID}_{TASK_ID}_vidOffset" at the end of each run and then pulled on the next to be used as an offset. As such, while accessing the Contacts endpoint, "max_active_runs" should be set to 1 to avoid pulling the same incremental key offset and therefore pulling the same data twice.
+
 * Campaigns - Rebuild
 * Companies - Rebuild
 * Contacts - Append - Built based on incremental contact id
-   * Form Submissions - Append
-   * Identity Profiles - Append
-   * List Memberships - Append
-   * Merge Audits - Append
+  * Form Submissions - Append
+  * Identity Profiles - Append
+  * List Memberships - Append
+  * Merge Audits - Append
 * Deals - rebuild
-   * Associations_AssociatedVids - Append
-   * Associations_AssociatedCompanyVids - Append
-   * Associations_AssociatedDealIds - Append
+  * Associations_AssociatedVids - Append
+  * Associations_AssociatedCompanyVids - Append
+  * Associations_AssociatedDealIds - Append
 * Deal Pipelines - Rebuild
 * Engagments - Rebuild
-   * Associations - Rebuild
-   * Attachments - Rebuild
+  * Associations - Rebuild
+  * Attachments - Rebuild
 * Events - Append - Built based on incremental date
 * Forms - Rebuild
-   * Field Groups - Rebuild
+  * Field Groups - Rebuild
 * Keywords - Rebuild
 * Lists - Rebuild
-   * Filters - Rebuild
+  * Filters - Rebuild
 * Owners - Rebuild
-   * Remote List - Rebuild
+  * Remote List - Rebuild
 * Social - Rebuild
 * Timeline - Append - Built based on incremental date
 * Workflow - Rebuild
-   * Persona Tag Ids - Rebuild
+  * Persona Tag Ids - Rebuild
   * Contact List Ids Steps - Rebuild
-
 
 Before we get started, be sure you have the following on hand:
 
@@ -97,6 +97,7 @@ Navigate back into your project directory and create a `dags` folder by running 
 ### 4. Customize
 
 Open up the [hubspot_to_redshift.py file](https://github.com/airflow-plugins/Example-Airflow-DAGs/blob/master/etl/hubspot_to_redshift.py#L74) from the repo you just cloned in a text editor of your choice and input the following credentials in lines 74-78:
+
 ```
 S3_CONN_ID = ''
 S3_BUCKET = ''
@@ -108,7 +109,5 @@ REDSHIFT_CONN_ ''
 ### 5. Test + Deploy
 
 Once you have those credentials plugged into your DAG, test and deploy it!
-
-
 
 If you don't have Airflow already set up in your production environment, head over to [our app](https://app.astronomer.io/signup) to get spun up with your own managed instance!

--- a/guides/imap-to-redshift.md
+++ b/guides/imap-to-redshift.md
@@ -20,7 +20,6 @@ Before we get started, be sure you have the following on hand:
   instance via Astronomer, but the core code should work the same regardless of how you’re hosting Airflow
 * Docker running on your machine
 
-
 ### 1. Add Connections in Airflow UI
 
 Begin by creating all of the necessary connections in your Airflow UI. To do this, log into your Airflow dashboard and navigate to Admin-->Connections. In order to build this pipeline, you’ll need to create a connection to your IMAP server, your S3 bucket, and your Redshift instance. For more info on how to fill out the fields within your connections, check out our [documentation here](https://docs.astronomer.io/v2/apache_airflow/tutorial/connections.html).
@@ -31,7 +30,7 @@ If you haven't done so already, navigate into your project directory and create 
 
 `git clone https://github.com/airflow-plugins/imap_analytics_plugin.git`
 
-This will allow you to use the IMAP hook to access your IMAP server, search your inbox for emails with specific subjects, pull in the csv attachments of the emails, and store them in S3 using the IMAP to S3 operator. 
+This will allow you to use the IMAP hook to access your IMAP server, search your inbox for emails with specific subjects, pull in the csv attachments of the emails, and store them in S3 using the IMAP to S3 operator.
 
 ### 3. Copy the DAG file
 
@@ -40,6 +39,7 @@ Navigate back into your project directory and create a `dags` folder by running 
 ### 4. Customize
 
 Open up the [google_analytics_to_redshift.py file](https://github.com/airflow-plugins/Example-Airflow-DAGs/blob/master/etl/imap_to_redshift.py#L25) that you just copied in a text editor of your choice and input the following credentials into lines 25-34:
+
 ```py
 IMAP_CONN_ID = ''
 IMAP_EMAIL = ''

--- a/guides/install-aws-stateful-set.md
+++ b/guides/install-aws-stateful-set.md
@@ -8,6 +8,7 @@ tags: ["Airflow", "AWS", "Product Documentation"]
 ---
 
 Create a new `.yaml` filem you can call it `storageclass.yaml` and add the following:
+
 ```
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
@@ -21,5 +22,6 @@ parameters:
 reclaimPolicy: Retain
 mountOptions:
   - debug
-  ```
-You can now run `kubectl apply -f storageclass.yaml` to apply this to your kubernetes cluster. 
+```
+
+You can now run `kubectl apply -f storageclass.yaml` to apply this to your kubernetes cluster.

--- a/guides/install-aws.md
+++ b/guides/install-aws.md
@@ -7,7 +7,7 @@ heroImagePath: "https://cdn.astronomer.io/website/img/guides/TheAirflowUI_previe
 tags: ["Astronomer Platform", "Getting Started"]
 ---
 
-This guide describes the prerequisite steps to install Astronomer on Amazon Web Services (AWS).  
+This guide describes the prerequisite steps to install Astronomer on Amazon Web Services (AWS).
 
 ## Are you admin-y enough to do this alone?
 
@@ -27,7 +27,7 @@ Before running the Astronomer install command you must:
 1. [Get a Postgres server running](/guides/install-postgres)
 1. [Obtain SSL](/guides/install-ssl)
 1. [Set a few Kubernetes secrets](/guides/install-k8s-secrets)
-1. [Create Google OAuth Creds ](/guides/install-google-oauth)
+1. [Create Google OAuth Creds](/guides/install-google-oauth)
 1. [Build your config.yaml](/guides/install-config)
 1. [Create a stateful storage set](/guides/install-aws-stateful-set)
 
@@ -36,8 +36,9 @@ Before running the Astronomer install command you must:
 You're ready to go!
 
 ```shell
-$ helm install -f config.yaml . --namespace astronomer
+helm install -f config.yaml . --namespace astronomer
 ```
+
 ## DNS routing
 
 Your final step is to setup your DNS to route traffic to your airflow resources following [these steps](/guides/install-aws-dns).

--- a/guides/install-dev-env.md
+++ b/guides/install-dev-env.md
@@ -6,13 +6,15 @@ slug: "install-dev-env"
 heroImagePath: "https://cdn.astronomer.io/website/img/guides/TheAirflowUI_preview.png"
 tags: ["admin-docs"]
 ---
+
 ## GCP
+
 * Install Google Cloud CLI [Google Cloud SDK](https://cloud.google.com/sdk/install)
 * Initialize gcloud to use your Google Cloud Project [gclouf init](https://cloud.google.com/sdk/gcloud/reference/init)
 
 ## AWS
-* Install the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/installing.html) and [Heptio Authenticator](https://docs.aws.amazon.com/eks/latest/userguide/configure-kubectl.html)
 
+* Install the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/installing.html) and [Heptio Authenticator](https://docs.aws.amazon.com/eks/latest/userguide/configure-kubectl.html)
 
 ## General
 

--- a/guides/install-gcp.md
+++ b/guides/install-gcp.md
@@ -10,7 +10,6 @@ tags: ["admin-docs"]
 This guide describes the process to install Astronomer on Google Cloud Platform
 (GCP).
 
-
 ## Are you admin-y enough to do this alone?
 
 You will need to be able to:
@@ -32,7 +31,7 @@ Before running the Astronomer install command you must:
 1. [Obtain SSL](/guides/install-ssl)
 1. [Setup DNS](/guides/install-dns)
 1. [Set a few Kubernetes secrets](/guides/install-k8s-secrets)
-1. [Create Google OAuth Creds ](/guides/install-google-oauth)
+1. [Create Google OAuth Creds](/guides/install-google-oauth)
 1. [Build your config.yaml](/guides/install-config)
 
 ## Install Astronomer
@@ -40,7 +39,7 @@ Before running the Astronomer install command you must:
 You're ready to go!
 
 ```shell
-$ helm install -f config.yaml . --namespace astronomer
+helm install -f config.yaml . --namespace astronomer
 ```
 
 Click the link in the output notes to log in to the Astronomer app.

--- a/guides/install-google-oauth.md
+++ b/guides/install-google-oauth.md
@@ -26,7 +26,7 @@ Visit the Google [cloud console](https://console.cloud.google.com/)
 
 If you already have an existing project you want to use, you can skip to Step 3
 
-In the top nav, you will have a dropdown with a label of either a currently selected project or `Select a project`.  
+In the top nav, you will have a dropdown with a label of either a currently selected project or `Select a project`.
 
 ![select-project](https://cdn.astronomer.io/website/img/guides/google-oauth-creds/select-project.png)
 
@@ -78,12 +78,12 @@ Once these fields have been filled out, click the `Create` button in the bottom 
 
 ### Step 7: Copy your "clientID" and "clientSecret"
 
-After creating your credentials, Google will redirect you back to the credentials page and popup a window with your newly created OAuth client credentials.  
+After creating your credentials, Google will redirect you back to the credentials page and popup a window with your newly created OAuth client credentials.
 
 ![copy-client-id-secret](https://cdn.astronomer.io/website/img/guides/google-oauth-creds/copy-client-id-secret.png)
 
 If you accidentally close this, or need to refer to them at a later date, clicking the name of the credentials you just created in the list of credentials on this page will display them.
 
-You'll want to copy the clientID and clientSecret into the helm config file you are prepping for the Astronomer Helm install.  
+You'll want to copy the clientID and clientSecret into the helm config file you are prepping for the Astronomer Helm install.
 
 That's it!

--- a/guides/install-postgres.md
+++ b/guides/install-postgres.md
@@ -19,5 +19,5 @@ For testing purposes, you can quickly get started using the PostgreSQL helm char
 Run:
 
 ```shell
-$ helm install --name astro-db stable/postgresql --namespace astronomer
+helm install --name astro-db stable/postgresql --namespace astronomer
 ```

--- a/guides/install-ssl.md
+++ b/guides/install-ssl.md
@@ -24,7 +24,7 @@ We recommend purchasing a TLS certificate signed by a Trusted CA. Alternatively 
 Run:
 
 ```shell
-$ docker run -it --rm --name letsencrypt -v /etc/letsencrypt:/etc/letsencrypt -v /var/lib/letsencrypt:/var/lib/letsencrypt certbot/certbot:latest certonly -d "*.astro.mycompany.com" --manual --preferred-challenges dns --server https://acme-v02.api.letsencrypt.org/directory
+docker run -it --rm --name letsencrypt -v /etc/letsencrypt:/etc/letsencrypt -v /var/lib/letsencrypt:/var/lib/letsencrypt certbot/certbot:latest certonly -d "*.astro.mycompany.com" --manual --preferred-challenges dns --server https://acme-v02.api.letsencrypt.org/directory
 ```
 
 Sample output:

--- a/guides/install.md
+++ b/guides/install.md
@@ -31,7 +31,7 @@ Note: Self-signed certificates are not supported on the Astronomer Platform.
 Run:
 
 ```shell
-$ docker run -it --rm --name letsencrypt -v /etc/letsencrypt:/etc/letsencrypt -v /var/lib/letsencrypt:/var/lib/letsencrypt certbot/certbot:latest certonly -d "*.astro.mycompany.com" --manual --preferred-challenges dns --server https://acme-v02.api.letsencrypt.org/directory
+docker run -it --rm --name letsencrypt -v /etc/letsencrypt:/etc/letsencrypt -v /var/lib/letsencrypt:/var/lib/letsencrypt certbot/certbot:latest certonly -d "*.astro.mycompany.com" --manual --preferred-challenges dns --server https://acme-v02.api.letsencrypt.org/directory
 ```
 
 Sample output:
@@ -76,17 +76,17 @@ This PostgreSQL user needs permissions to create users, schemas, databases, and 
 For testing purposes, you can quickly get started using the PostgreSQL helm chart.
 
 Run:
+
 ```shell
-$ helm install --name astro-db stable/postgresql --namespace astronomer
+helm install --name astro-db stable/postgresql --namespace astronomer
 ```
 
 Depending on where your Postgres cluster is running, you may need to adjust the connection string in the next step to match your environment. If you installed via the helm chart, you can run the command that was output by helm to set the `${PGPASSWORD}` environment variable, which can be used in the next step. Once that variable is set, you can run this command directly to create the bootstrap secret.
 
-
 Run:
 
 ```shell
-$ kubectl create secret generic astronomer-bootstrap --from-literal connection="postgres://postgres:${PGPASSWORD}@astro-db-postgresql:5432" --namespace astronomer
+kubectl create secret generic astronomer-bootstrap --from-literal connection="postgres://postgres:${PGPASSWORD}@astro-db-postgresql:5432" --namespace astronomer
 ```
 
 Note: Change user from `postgres` if you're creating a user instead of using the default, it needs permission to create databases, schemas, and users.
@@ -94,7 +94,7 @@ Note: Change user from `postgres` if you're creating a user instead of using the
 ## 4. Create a Kubernetes secret for the TLS certificates
 
 ```shell
-$ kubectl create secret tls astronomer-tls --key /etc/letsencrypt/live/astro.mycompany.com/privkey.pem --cert /etc/letsencrypt/live/astro.mycompany.com/fullchain.pem --namespace astronomer
+kubectl create secret tls astronomer-tls --key /etc/letsencrypt/live/astro.mycompany.com/privkey.pem --cert /etc/letsencrypt/live/astro.mycompany.com/fullchain.pem --namespace astronomer
 ```
 
 ## 5. Generate credentials for Google OAuth
@@ -131,7 +131,7 @@ Replace `<your-client-id>` and `<your-client-secret>` with the values from the p
 ## 7. Install Astronomer
 
 ```shell
-$ helm install -f config.yaml . --namespace astronomer
+helm install -f config.yaml . --namespace astronomer
 ```
 
 Click the link in the output notes to log in to the Astronomer app.

--- a/guides/kerberos.md
+++ b/guides/kerberos.md
@@ -24,7 +24,7 @@ Core support for Kerberos in Airflow is there including a ticket renewer service
 For Kerberos support in Airflow, install it with the `kerberos` install option:
 
 ```shell
-$ pip install apache-airflow[kerberos]
+pip install apache-airflow[kerberos]
 ```
 
 ## Kerberized Hooks
@@ -58,7 +58,7 @@ If you want to use Kerberos authentication via Airflow's experimental REST API, 
 You can start the Kerberos ticket renewer service via the Airflow CLI
 
 ```shell
-$ airflow kerberos ...
+airflow kerberos ...
 ```
 
 See [Airflow CLI - Kerberos](https://airflow.readthedocs.io/en/latest/cli.html#kerberos) for more info.

--- a/guides/managing-dependencies.md
+++ b/guides/managing-dependencies.md
@@ -21,16 +21,16 @@ Dependencies can be set syntactically or through bitshift operators.
 
 ![title](https://cdn.astronomer.io/website/img/guides/simple_scheduling.png)
 
-
 This logic can be set three ways:
+
 - `d1.set_downstream(d2)`<br> `d2.set_downstream(d3)` <br> `d3.set_downstream(d4)`<br> <br>
 - `d4.set_upstream(d3)` <br> `d3.set_upstream(d2)` <br> `d2.set_upstream(d1)`<br> <br>
 - `d1 >> d2 >> d3 >> d4` <br> <br>
 - `d4 << d3 << d2 << d1`
 
 All three are in line with best practice as long as it is written consistently - do **not** do:
-- `d1.set_downstream(d2)`<br> `d2 >>d3` <br> `d4.set_upstream(d3)`<br>
 
+- `d1.set_downstream(d2)`<br> `d2 >>d3` <br> `d4.set_upstream(d3)`<br>
 
 ## Dynamically Setting Dependencies
 
@@ -38,9 +38,7 @@ For a large number of tasks, dependencies can be set in loops:
 
 ![title](https://cdn.astronomer.io/website/img/guides/loop_dependencies.png)
 
-
 Recall that tasks are identified by their `task_id` and associated `DAG` object - not by the type of operator. Consider this:
-
 
 ```python
 with dag:
@@ -59,7 +57,7 @@ with dag:
 
 _ What happens here?_
 
-##  Trigger Rules
+## Trigger Rules
 
 _Complex Dependencies_
 
@@ -82,8 +80,8 @@ TriggerRules are defined as Airlfow Utils:
 _Extendability vs Safety_
 
 ### The `one_failed` rule
-When you have a critically important but _brittle_ task in a workflow (i.e. a large machine learning job, some reporting task, etc.), a good safety check would be adding a task that handles the failure logic. This logic can be implemented dynamically based on how the DAG is being generated.
 
+When you have a critically important but _brittle_ task in a workflow (i.e. a large machine learning job, some reporting task, etc.), a good safety check would be adding a task that handles the failure logic. This logic can be implemented dynamically based on how the DAG is being generated.
 
 ```python
 # Define the tasks that are "brittle."
@@ -111,9 +109,9 @@ def fail_logic(**kwargs):
 with dag:
     for job in job_info:
         d1 = DummyOperator(task_id=job['job_name'])
-        
+
         # Generate a task based on a condition
-        
+
         if job['brittle']:
             d2 = PythonOperator(task_id='{0}_{1}'.format(job['job_name'],
                                                          'fail_logic',),
@@ -128,21 +126,19 @@ with dag:
             d1 >> downstream
 ```
 
-
 ![one_failed](https://cdn.astronomer.io/website/img/guides/fail_logic_notification.png)
-
 
 **Note:** Similar logic can be implemented by specifying an `on_failure_callback` if using a PythonOperator. The `trigger_rule` is better used when triggering a custom operator.
 
 Though trigger rules can be convenient, they can also be unsafe and the same logic can usually be implemented using safer features.
 
-A common use case of exotic trigger rules is a task downstream of all  other tasks that kicks off the necessary logic. 
+A common use case of exotic trigger rules is a task downstream of all  other tasks that kicks off the necessary logic.
 
 ### The `one_success` rule
+
 This rule is particulary helpful when setting up a "safety check" DAG - a DAG that runs as a safetycheck to all your data. If one of the "disaster checks" come back as `True`, the downstream disaster task can run the necessary logic.
 
 **Note:** The same logic can be implemented with the `one_failed` rule.
-
 
 ### The `all_failed` rule
 
@@ -157,10 +153,9 @@ Once again, the same functionality can be achieved by using the `PythonBranchOpe
 
 ## Triggers with LatestOnlyOperator
 
-When scheduling tasks with complex trigger rules with dates in the past, there may be instances where certain tasks can run independely of time and others shouldn't. 
+When scheduling tasks with complex trigger rules with dates in the past, there may be instances where certain tasks can run independely of time and others shouldn't.
 
 The parameters can also be set in the DAG configuration as above - the scheduling may get a bit messy, but it can save computing resources and add a layer of safety.
-
 
 ```python
 job_info = [

--- a/guides/marketo-to-redshift.md
+++ b/guides/marketo-to-redshift.md
@@ -11,21 +11,22 @@ In this guide, we’ll explore how you can use [Apache Airflow](https://airflow.
 
 Before we get started, be sure you have the following on hand:
 
-* A Marketo account
-* An S3 bucket with a valid `aws_access_key_id` and `aws_secret_access_key`
-* A Redshift instance with a valid host IP and login information
-* An instance of Apache Airflow. You can either set this up yourself if you have devops resources or sign
+- A Marketo account
+- An S3 bucket with a valid `aws_access_key_id` and `aws_secret_access_key`
+- A Redshift instance with a valid host IP and login information
+- An instance of Apache Airflow. You can either set this up yourself if you have devops resources or sign
   up and get going immediately with Astronomer’s managed Airflow service. Note that this guide will use
   commands using the Astronomer CLI to push dags into production and will assume you’ve spun up an Airflow
   instance via Astronomer, but the core code should work the same regardless of how you’re hosting Airflow
-* Docker running on your machine
+- Docker running on your machine
 
 This ongoing DAG pulls the following Marketo objects:
-    - Activities
-    - Campaigns
-    - Leads
-    - Lead Lists
-    - Programs
+
+- Activities
+- Campaigns
+- Leads
+- Lead Lists
+- Programs
 
 Note that, when backfilling, only the leads object is pulled. By default, it begins
 pulling since Jan 1, 2013.
@@ -64,12 +65,9 @@ hourly_id = '{}_to_redshift_hourly'.format(MARKETO_CONN_ID)
 daily_id = '{}_to_redshift_daily_backfill'.format(MARKETO_CONN_ID)
 monthly_id = '{}_to_redshift_monthly_backfill'.format(MARKETO_CONN_ID)
 ```
-```
 
 ### 5. Test + Deploy
 
 Once you have those credentials plugged into your DAG, test and deploy it!
-
-
 
 If you don't have Airflow already set up in your production environment, head over to [our app](https://app.astronomer.io/signup) to get spun up with your own managed instance!

--- a/guides/mongo-to-redshift.md
+++ b/guides/mongo-to-redshift.md
@@ -20,7 +20,6 @@ Before we get started, be sure you have the following on hand:
   instance via Astronomer, but the core code should work the same regardless of how you’re hosting Airflow
 * Docker running on your machine
 
-
 This DAG uses a Mongo collection processing script that accepts a json formatted Mongo schema mapping and outputs both a Mongo query projection and a compatible Redshift schema mapping. This script can be found [here](https://github.com/airflow-plugins/Example-Airflow-DAGs/blob/master/etl/mongo_to_redshift/collections/_collection_processing.py).This DAG also contains a flattening script that removes invalid characters from the Mongo keys as well as scrubbing out the "_$date" suffix that PyMongo appends to datetime fields.
 
 ### 1. Add Connections in Airflow UI
@@ -55,7 +54,5 @@ MONGO_DATABASE = ''
 ### 5. Test + Deploy
 
 Once you have those credentials plugged into your DAG, test and deploy it!
-
-
 
 If you don't have Airflow already set up in your production environment, head over to [our app](https://app.astronomer.io/signup) to get spun up with your own managed instance!

--- a/guides/salesforce-to-redshift.md
+++ b/guides/salesforce-to-redshift.md
@@ -33,7 +33,6 @@ This plugin will allow you to pull the following Salesforce objects into your Re
 * Task
 * User
 
-
 ### 1. Add Connections in Airflow UI
 
 Begin by creating all of the necessary connections in your Airflow UI. To do this, log into your Airflow dashboard and navigate to Admin-->Connections. In order to build this pipeline, you’ll need to create a connection to your Salesforce account, your S3 bucket, and your Redshift instance. For more info on how to fill out the fields within your connections, check out our [documentation here](https://docs.astronomer.io/v2/apache_airflow/tutorial/connections.html).
@@ -57,7 +56,5 @@ Open up the `salesforce_to_redshift.py` file from the repo you just cloned in a 
 ### 5. Test + Deploy
 
 Once you have those credentials plugged into your DAG, test and deploy it!
-
-
 
 If you don't have Airflow already set up in your production environment, head over to [our app](https://app.astronomer.io/signup) to get spun up with your own managed instance!

--- a/guides/scheduling-tasks.md
+++ b/guides/scheduling-tasks.md
@@ -44,33 +44,33 @@ from airflow.operators.bash_operator import BashOperator
 from datetime import datetime, timedelta
 
 default_args = {
-	'owner': 'airflow',
-	'depends_on_past': False,
-	'start_date': datetime(2018, 1, 1),
-	'email_on_failure': False,
-	'email_on_retry': False,
-	'retries': 1,
-	'retry_delay': timedelta(minutes=5),
+    'owner': 'airflow',
+    'depends_on_past': False,
+    'start_date': datetime(2018, 1, 1),
+    'email_on_failure': False,
+    'email_on_retry': False,
+    'retries': 1,
+    'retry_delay': timedelta(minutes=5),
 }
 
 dag = DAG('example_dag_one',
-			schedule_interval='@daily',
-			default_args=default_args)
+            schedule_interval='@daily',
+            default_args=default_args)
 
 t1 = BashOperator(
-	task_id='print_date1',
-	bash_command='sleep 2m',
-	dag=dag)
+    task_id='print_date1',
+    bash_command='sleep 2m',
+    dag=dag)
 
 t2 = BashOperator(
-	task_id='print_date2',
-	bash_command='sleep 2m',
-	dag=dag)
+    task_id='print_date2',
+    bash_command='sleep 2m',
+    dag=dag)
 
 t3 = BashOperator(
-	task_id='print_date3',
-	bash_command='sleep 2m',
-	dag=dag)
+    task_id='print_date3',
+    bash_command='sleep 2m',
+    dag=dag)
 
 t2.set_upstream(t1)
 t3.set_upstream(t2)
@@ -94,34 +94,34 @@ from airflow.operators.bash_operator import BashOperator
 from datetime import datetime, timedelta
 
 default_args = {
-	'owner': 'airflow',
-	'depends_on_past': False,
-	'start_date': datetime(2018, 1, 1),
-	'email_on_failure': False,
-	'email_on_retry': False,
-	'retries': 1,
-	'retry_delay': timedelta(minutes=5),
+    'owner': 'airflow',
+    'depends_on_past': False,
+    'start_date': datetime(2018, 1, 1),
+    'email_on_failure': False,
+    'email_on_retry': False,
+    'retries': 1,
+    'retry_delay': timedelta(minutes=5),
 }
 
 dag = DAG('example_dag_one',
-			schedule_interval='@daily',
+            schedule_interval='@daily',
             catchup=False,
-			default_args=default_args)
+            default_args=default_args)
 
 t1 = BashOperator(
-	task_id='print_date1',
-	bash_command='sleep 2m',
-	dag=dag)
+    task_id='print_date1',
+    bash_command='sleep 2m',
+    dag=dag)
 
 t2 = BashOperator(
-	task_id='print_date2',
-	bash_command='sleep 2m',
-	dag=dag)
+    task_id='print_date2',
+    bash_command='sleep 2m',
+    dag=dag)
 
 t3 = BashOperator(
-	task_id='print_date3',
-	bash_command='sleep 2m',
-	dag=dag)
+    task_id='print_date3',
+    bash_command='sleep 2m',
+    dag=dag)
 
 t2.set_upstream(t1)
 t3.set_upstream(t2)
@@ -223,7 +223,7 @@ with dag:
 
 
         start >> google_analytics >> s3_to_redshift
-```        
+```
 
 ![](https://cdn.astronomer.io/website/img/guides/ucg_ga_ga_scheduled.png)
 

--- a/guides/subdags.md
+++ b/guides/subdags.md
@@ -8,6 +8,7 @@ tags: ["Building DAGs", "Subdags", "Airflow"]
 ---
 
 # Subdags
+
 _Aesthetically appealing, but fragile._
 
 Most DAGs consist of patterns that often repeat themselves. ETL DAGs that are written to best practice usually all share the pattern of grabbing data from a source, loading it to an intermediary file store or _staging_ table, and then pushing it into production data.
@@ -30,9 +31,7 @@ The zoomed view reveals a granular view of the task:
 
 ![tasks](https://cdn.astronomer.io/website/img/guides/subdag_tasks.png)
 
-
 Subdags should be generated through a "DAG factory" - an external file that returns dag objects.
-
 
 ```python
 def load_subdag(parent_dag_name, child_dag_name, args):
@@ -55,7 +54,6 @@ def load_subdag(parent_dag_name, child_dag_name, args):
 
 This object should then be called when instanstiating the SubDagOperator:
 
-
 ```python
 load_tasks = SubDagOperator(
         task_id='load_tasks',
@@ -71,15 +69,16 @@ load_tasks = SubDagOperator(
 - SubDags should be scheduled the same as their parent DAGs or unexpected behavior might occur.
 
 ## Avoiding Deadlock
+
 _Greedy subdags_
 
 SubDags are not currently first class citizens in Airflow. Although it is in the community's roadmap to fix this, many organizations using Airflow have outright banned them because of how they are executed.
 
 ### Slots on the worker pool
+
 The SubDagOperator kicks off an entire DAG when it is put on a worker slot. Each task in the child DAG takes up a slot until the entire SubDag has completed. The parent operator will take up a worker slot until each child task has completed. This could cause delays in other task processing
 
 In mathematical terms, each SubDag is behaving like a _vertex_ (a single point in a graph) instead of a _graph_.
-
 
 Depending on the scale and infrastructure, a specialized queue can be added just for SubDags (assuming a CeleryExecutor), but a cleaner workaround is to avoid subdags entirely.
 

--- a/guides/templating.md
+++ b/guides/templating.md
@@ -14,15 +14,14 @@ Apart from efficiency, they're also powerful tools in forcing jobs to be idempot
 A list of default variables accessible in all templates can be found here: https://airflow.apache.org/code.html#macros
 
 Common macros include:
+
 - A timestamp for incremental ETL
 - A decryption key for an external system
 - Custom user defined parameters for complex operators
 
-
 ## Setting a Template
 
 Templates can be sit directly in the DAG file:
-
 
 ```python
 dag = DAG('example_template_once_v2',
@@ -56,15 +55,14 @@ Since templated information is rendered at run-time, it can be helpful to see wh
 
 From the Github to Redshift workflow we have been working with, we execute a post load transform to make reporting easier:
 
-
 ```python
 get_individual_issue_counts = \
     """
     INSERT INTO github.issue_count_by_user
     (SELECT login, sum(count) as count, timestamp
      FROM
-            ((SELECT 
-                m.login, count(i.id), 
+            ((SELECT
+                m.login, count(i.id),
                 cast('{{ execution_date + macros.timedelta(hours=-4) }}' as timestamp) as timestamp
             FROM github.astronomerio_issues i
             JOIN github.astronomerio_members m
@@ -73,8 +71,8 @@ get_individual_issue_counts = \
             GROUP BY m.login
             ORDER BY login)
         UNION
-            (SELECT 
-                m.login, count(i.id), 
+            (SELECT
+                m.login, count(i.id),
                 cast('{{ execution_date + macros.timedelta(hours=-4) }}' as timestamp) as timestamp
             FROM github.astronomerio_issues i
             JOIN github.astronomerio_members m
@@ -83,9 +81,9 @@ get_individual_issue_counts = \
             GROUP BY m.login
             ORDER BY login)
         UNION
-            (SELECT 
-                m.login, 
-                count(i.id), 
+            (SELECT
+                m.login,
+                count(i.id),
                 cast('{{ execution_date + macros.timedelta(hours=-4) }}' as timestamp) as timestamp
             FROM github."airflow-plugins_issues" i
             JOIN github."airflow-plugins_members" m
@@ -105,7 +103,7 @@ On the *Rendered* tab
 
 ![rendered_sql](https://cdn.astronomer.io/website/img/guides/rendered_sql.png)
 
-The corresponding timestamp has been rendered into the TaskInstance. 
+The corresponding timestamp has been rendered into the TaskInstance.
 
 ## Using Templating for Idempotency
 
@@ -119,14 +117,12 @@ Luckily, this usually only requires changing a few lines of code:
  <br>
 https://github.com/airflow-plugins/google_analytics_plugin/blob/master/operators/google_analytics_reporting_to_s3_operator.py#L41
 
-
 ```python
 template_fields = ('s3_key', 'since', 'until')
 ```
 
 2) Define the corresponding values in the DAG file:<br>
 https://github.com/airflow-plugins/Example-Airflow-DAGs/blob/master/etl/google_analytics_to_redshift.py#L131
-
 
 ```python
 SINCE = "{{{{ macros.ds_add(ds, -{0}) }}}}".format(str(LOOKBACK_WINDOW))
@@ -141,7 +137,6 @@ S3_KEY = 'google_analytics/{0}/{1}_{2}_{3}.json'.format(REDSHIFT_SCHEMA,
 3) Instantiate the Operator with the right values:
 
 https://github.com/airflow-plugins/Example-Airflow-DAGs/blob/master/etl/google_analytics_to_redshift.py#L136
-
 
 ```python
 g = GoogleAnalyticsReportingToS3Operator(task_id='get_google_analytics_data',
@@ -165,7 +160,6 @@ g = GoogleAnalyticsReportingToS3Operator(task_id='get_google_analytics_data',
 Since macros are rendered at runtime, a DAG's `schedule_interval` should be taken into account when testing and deploying DAGs.
 
 Consider the following DAG:
-
 
 ```python
 from airflow import DAG

--- a/guides/trigger-dag-operator.md
+++ b/guides/trigger-dag-operator.md
@@ -21,7 +21,6 @@ The TriggerDagRunOperator needs a controller - a task that decides the outcome b
 
 The controller task takes the form a python callable:
 
-
 ```python
 def conditionally_trigger(context, dag_run_obj):
     """
@@ -38,7 +37,6 @@ def conditionally_trigger(context, dag_run_obj):
 
 If the `dag_run_obj` is returned, the target DAG can will be triggered. The `dag_run_obj` can also be passed with context parameters.
 
-
 ```python
 def target_function(**kwargs):
     print("Remotely received value of {} for key=message".
@@ -49,7 +47,7 @@ The `target` DAG should always be set to `None` for its schedule - the DAG shoul
 
 ## Use Cases
 
-Trigger DAGs are a great way to separate the logic between a "safety check" and the logic to execute in case those checks aren't accomplished. 
+Trigger DAGs are a great way to separate the logic between a "safety check" and the logic to execute in case those checks aren't accomplished.
 
 These sorts of checks are a good fail safe to add to the end of a workflow, downstream of the data ingestion layer.
 
@@ -59,15 +57,16 @@ On the same note, they can be used to monitor Airflow itself.
 
 Error notifications can be set through various levels through a DAG, but propogating whose  between different DAGs can valuable for other reasons. Suppose that after 5  DAG failures, you wanted to trigger a systems check
 
-
 ### Sensors and TriggerDAGs
+
 _Airflow on Airflow._
 
 As Airflow operations are being scaled up, error reporting gets increasingly difficult. The more failure emails that are being sent out, the less each notification matters. Furthermore, a certain threshold of failures could indiciate a deeper issue in another system.
 
 Using a Sensor and TriggerDag can provide a clean solution to this issue,
 
-####  Checking the database for a threshold of failures.
+#### Checking the database for a threshold of failures.
+
 _DagFailureSensor_
 
 A sensor can be used to check the metadatabase for the status of DagRuns. If the number of failed runs is above a certain threshold (different for each DAG), the next task can trigger a systems check DAG.
@@ -92,6 +91,7 @@ checks = [
 ```
 
 The sensor can then be implemented as such:
+
 ```python
 for check in checks:
     sensor = DagFailureSensor(task_id='sensor_task_{0}'
@@ -108,10 +108,11 @@ for check in checks:
                                         python_callable=trigger_sys_dag)
     first_task >> sensor >> trigger
 ```
+
 ![system_check_controller](https://cdn.astronomer.io/website/img/guides/system_check_controller.png)
 
-
 #### Adding Trigger Rules
+
 Depending on the rest of the infrastructure, different "checks" may all trigger the same system level check.
 
 If that is the case, TriggerDagOperators should be set with a different `trigger_rule`
@@ -138,5 +139,5 @@ with dag:
 
         first_task >> sensor >> trigger
 ```
-![system_check_controller](https://cdn.astronomer.io/website/img/guides/trigger_rule_sensor_dag.png)
 
+![system_check_controller](https://cdn.astronomer.io/website/img/guides/trigger_rule_sensor_dag.png)


### PR DESCRIPTION
Fixes 285 linter errors.

This runs markdownlint against everything in guides and fixes each error.

For some reason adding an .mdlrc config file isn't working, so I included the excluded rules manually.
```
$ mdl -r ~MD002,~MD013,~MD024,~MD026,~MD033,~MD034,~MD036 guides
```
Before:
```
$ mdl -r ~MD002,~MD013,~MD024,~MD026,~MD033,~MD034,~MD036 guides | wc -l
     285
```
After:
```
$ mdl -r ~MD002,~MD013,~MD024,~MD026,~MD033,~MD034,~MD036 guides | wc -l
       0
```